### PR TITLE
Fix skill examples not rotating

### DIFF
--- a/ui/idle.qml
+++ b/ui/idle.qml
@@ -163,13 +163,16 @@ Mycroft.CardDelegate {
             textTimer.runEntryChangeB()
             var index = idleRoot.textModel.indexOf(exampleEntry);
             var nextItem;
-            if(index >= 0) {
+            if(index >= 0 && index < idleRoot.textModel.length - 1) {
                 nextItem = idleRoot.textModel[index + 1]
-                idleRoot.exampleEntry = nextItem
-                exampleEntryUpdate(exampleEntry)
+            } else {
+                nextItem = idleRoot.textModel[0]
             }
+            idleRoot.exampleEntry = nextItem;
+            exampleEntryUpdate(exampleEntry);
         }, 500);
     }
+
 
     Timer {
         id: textTimer


### PR DESCRIPTION
The examples would run to the end of the list and not rotate back to the beginning.  Therefore leaving the last entry in the examples list showing.  This runs to the end of the list and resets it back to the beginning.