### PR TITLE
Make 'Ask Me' example prefix optional

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -74,8 +74,7 @@ class OVOSHomescreenSkill(MycroftSkill):
         self.examples_enabled = 1 if self.settings.get(
             "examples_enabled", True) else 0
 
-        self.examples_prefix = 1 if self.settings.get(
-            "examples_prefix", True) else 0
+        self.examples_prefix = self.settings.get("examples_prefix", True)
 
         if self.examples_enabled:
             self.skill_info_skill = self.settings.get(

--- a/__init__.py
+++ b/__init__.py
@@ -47,6 +47,7 @@ class OVOSHomescreenSkill(MycroftSkill):
 
         # A variable to turn on/off the example text
         self.examples_enabled = True
+        self.example_prefix = True
 
         # Display Configuration Variables
         self.wallpaper_rotation_enabled = False
@@ -72,6 +73,10 @@ class OVOSHomescreenSkill(MycroftSkill):
             "datetime_skill") or "skill-ovos-date-time.openvoiceos"
         self.examples_enabled = 1 if self.settings.get(
             "examples_enabled", True) else 0
+
+        self.example_prefix = 1 if self.settings.get(
+            "examples_prefix", True) else 0
+
         if self.examples_enabled:
             self.skill_info_skill = self.settings.get(
                 "examples_skill") or "ovos-skills-info.openvoiceos"
@@ -188,6 +193,7 @@ class OVOSHomescreenSkill(MycroftSkill):
         else:
             LOG.warning("No skill_info_api, skipping update")
         self.gui['skill_info_enabled'] = self.examples_enabled
+        self.gui['skill_info_prefix'] = self.example_prefix
 
     def update_dt(self):
         """

--- a/__init__.py
+++ b/__init__.py
@@ -47,7 +47,6 @@ class OVOSHomescreenSkill(MycroftSkill):
 
         # A variable to turn on/off the example text
         self.examples_enabled = True
-        self.examples_prefix = True
 
         # Display Configuration Variables
         self.wallpaper_rotation_enabled = False
@@ -73,8 +72,6 @@ class OVOSHomescreenSkill(MycroftSkill):
             "datetime_skill") or "skill-ovos-date-time.openvoiceos"
         self.examples_enabled = 1 if self.settings.get(
             "examples_enabled", True) else 0
-
-        self.examples_prefix = self.settings.get("examples_prefix", True)
 
         if self.examples_enabled:
             self.skill_info_skill = self.settings.get(
@@ -192,8 +189,8 @@ class OVOSHomescreenSkill(MycroftSkill):
         else:
             LOG.warning("No skill_info_api, skipping update")
         self.gui['skill_info_enabled'] = self.examples_enabled
-        LOG.debug(f'prefix={self.examples_prefix}')
-        self.gui['skill_info_prefix'] = self.examples_prefix
+        self.gui['skill_info_prefix'] = self.settings.get("examples_prefix",
+                                                          True)
 
     def update_dt(self):
         """

--- a/__init__.py
+++ b/__init__.py
@@ -47,7 +47,7 @@ class OVOSHomescreenSkill(MycroftSkill):
 
         # A variable to turn on/off the example text
         self.examples_enabled = True
-        self.example_prefix = True
+        self.examples_prefix = True
 
         # Display Configuration Variables
         self.wallpaper_rotation_enabled = False
@@ -74,7 +74,7 @@ class OVOSHomescreenSkill(MycroftSkill):
         self.examples_enabled = 1 if self.settings.get(
             "examples_enabled", True) else 0
 
-        self.example_prefix = 1 if self.settings.get(
+        self.examples_prefix = 1 if self.settings.get(
             "examples_prefix", True) else 0
 
         if self.examples_enabled:
@@ -193,7 +193,8 @@ class OVOSHomescreenSkill(MycroftSkill):
         else:
             LOG.warning("No skill_info_api, skipping update")
         self.gui['skill_info_enabled'] = self.examples_enabled
-        self.gui['skill_info_prefix'] = self.example_prefix
+        LOG.debug(f'prefix={self.examples_prefix}')
+        self.gui['skill_info_prefix'] = self.examples_prefix
 
     def update_dt(self):
         """

--- a/settingsmeta.yml
+++ b/settingsmeta.yml
@@ -24,4 +24,7 @@ skillMetadata:
           type: bool
           label: Enable Examples
           value: true
-
+        - name: examples_prefix
+          type: bool
+          label: Prefix examples with 'Ask Me'
+          value: true

--- a/ui/BottomWidgetsArea.qml
+++ b/ui/BottomWidgetsArea.qml
@@ -10,6 +10,7 @@ Item {
     id: bottomWidgetsAreaRootItem
     property bool verticalMode: false
     property bool examplesDisplayEnabled: sessionData.skill_info_enabled ?  sessionData.skill_info_enabled : 1
+    property bool examplesPrefixEnabled: sessionData.examples_info_prefix ? sessionData.examples_info_prefix : 1
     property bool mediaWidgetDisplayEnabled: idleRoot.mediaWidgetEnabled
 
     onMediaWidgetDisplayEnabledChanged: {
@@ -25,6 +26,7 @@ Item {
         visible: bottomWidgetsAreaRootItem.examplesDisplayEnabled && !mediaWidgetDisplay.enabled
         enabled: bottomWidgetsAreaRootItem.examplesDisplayEnabled && !mediaWidgetDisplay.enabled
         verticalMode: bottomWidgetsAreaRootItem.verticalMode
+        examplesPrefix: bottomWidgetsAreaRootItem.examplesPrefixEnabled
     }
 
     MediaWidgetDisplay {

--- a/ui/BottomWidgetsArea.qml
+++ b/ui/BottomWidgetsArea.qml
@@ -10,7 +10,6 @@ Item {
     id: bottomWidgetsAreaRootItem
     property bool verticalMode: false
     property bool examplesDisplayEnabled: sessionData.skill_info_enabled ?  sessionData.skill_info_enabled : 1
-    property bool examplesPrefixEnabled: sessionData.examples_info_prefix ? sessionData.examples_info_prefix : 1
     property bool mediaWidgetDisplayEnabled: idleRoot.mediaWidgetEnabled
 
     onMediaWidgetDisplayEnabledChanged: {
@@ -26,7 +25,6 @@ Item {
         visible: bottomWidgetsAreaRootItem.examplesDisplayEnabled && !mediaWidgetDisplay.enabled
         enabled: bottomWidgetsAreaRootItem.examplesDisplayEnabled && !mediaWidgetDisplay.enabled
         verticalMode: bottomWidgetsAreaRootItem.verticalMode
-        examplesPrefix: bottomWidgetsAreaRootItem.examplesPrefixEnabled
     }
 
     MediaWidgetDisplay {

--- a/ui/ExamplesDisplay.qml
+++ b/ui/ExamplesDisplay.qml
@@ -62,7 +62,7 @@ Rectangle {
                 verticalAlignment: Text.AlignVCenter
                 wrapMode: Text.WordWrap
                 font.weight: Font.DemiBold
-                text: '<i>“' + qsTr("Ask Me") + " " + idleRoot.exampleEntry + '“</i>'
+                text: '<i>“' + (idleRoot.examplesPrefix ? qsTr("Ask Me") : "") + " " + idleRoot.exampleEntry + '“</i>'
                 color: "white"
                 layer.enabled: true
                 layer.effect: DropShadow {

--- a/ui/ExamplesDisplay.qml
+++ b/ui/ExamplesDisplay.qml
@@ -63,7 +63,7 @@ Rectangle {
                 verticalAlignment: Text.AlignVCenter
                 wrapMode: Text.WordWrap
                 font.weight: Font.DemiBold
-                text: idleRoot.examplesPrefix ? '<i>“' + qsTr("Ask Me") + " "  + idleRoot.exampleEntry + '“</i>' : idleRoot.exampleEntry
+                text: '<i>“' + (idleRoot.examplesPrefix ? qsTr("Ask Me") + " ": "") + idleRoot.exampleEntry + '”</i>'
                 color: "white"
                 layer.enabled: true
                 layer.effect: DropShadow {

--- a/ui/ExamplesDisplay.qml
+++ b/ui/ExamplesDisplay.qml
@@ -63,7 +63,7 @@ Rectangle {
                 verticalAlignment: Text.AlignVCenter
                 wrapMode: Text.WordWrap
                 font.weight: Font.DemiBold
-                text: '<i>“' + (examplesDisplay.examplesPrefix ? qsTr("Ask Me") + " " : " ")  + idleRoot.exampleEntry + '“</i>'
+                text: idleRoot.examplesPrefix ? '<i>“' + qsTr("Ask Me") + " "  + idleRoot.exampleEntry + '“</i>' : idleRoot.exampleEntry
                 color: "white"
                 layer.enabled: true
                 layer.effect: DropShadow {

--- a/ui/ExamplesDisplay.qml
+++ b/ui/ExamplesDisplay.qml
@@ -8,6 +8,7 @@ import Mycroft 1.0 as Mycroft
 Rectangle {
     id: examplesDisplay
     property bool verticalMode: false
+    property bool examplesPrefix: true
     color: "transparent"
 
     Connections {
@@ -62,7 +63,7 @@ Rectangle {
                 verticalAlignment: Text.AlignVCenter
                 wrapMode: Text.WordWrap
                 font.weight: Font.DemiBold
-                text: '<i>“' + (idleRoot.examplesPrefix ? qsTr("Ask Me") : "") + " " + idleRoot.exampleEntry + '“</i>'
+                text: '<i>“' + (examplesDisplay.examplesPrefix ? qsTr("Ask Me") + " " : " ")  + idleRoot.exampleEntry + '“</i>'
                 color: "white"
                 layer.enabled: true
                 layer.effect: DropShadow {

--- a/ui/idle.qml
+++ b/ui/idle.qml
@@ -21,6 +21,7 @@ Mycroft.CardDelegate {
     property color shadowColor: Qt.rgba(0, 0, 0, 0.7)
     property bool rtlMode: sessionData.rtl_mode ? Boolean(sessionData.rtl_mode) : false
     property bool examplesEnabled: sessionData.skill_info_enabled ? Boolean(sessionData.skill_info_enabled) : true
+    property bool examplesPrefix: sessionData.skill_info_prefix ? Boolean(sessionData.skill_info_prefix) : true
     property bool weatherEnabled: sessionData.weather_api_enabled ? Boolean(sessionData.weather_api_enabled) : false
     property var dateFormat: sessionData.dateFormat ? sessionData.dateFormat : "DMY"
     property var timeString: sessionData.time_string ? sessionData.time_string : "00:00"

--- a/ui/idle.qml
+++ b/ui/idle.qml
@@ -21,7 +21,7 @@ Mycroft.CardDelegate {
     property color shadowColor: Qt.rgba(0, 0, 0, 0.7)
     property bool rtlMode: sessionData.rtl_mode ? Boolean(sessionData.rtl_mode) : false
     property bool examplesEnabled: sessionData.skill_info_enabled ? Boolean(sessionData.skill_info_enabled) : true
-    property bool examplesPrefix: sessionData.skill_info_prefix ? Boolean(sessionData.skill_info_prefix) : true
+    property bool examplesPrefix: sessionData.skill_info_prefix
     property bool weatherEnabled: sessionData.weather_api_enabled ? Boolean(sessionData.weather_api_enabled) : false
     property var dateFormat: sessionData.dateFormat ? sessionData.dateFormat : "DMY"
     property var timeString: sessionData.time_string ? sessionData.time_string : "00:00"


### PR DESCRIPTION
Adds a skill setting to disable the 'Ask Me' prefix in the homescreen examples display; default behavior is unchanged.