### PR TITLE
removed depreciated weather_skill from settingsmeta.yml

### DIFF
--- a/settingsmeta.yml
+++ b/settingsmeta.yml
@@ -2,10 +2,6 @@ skillMetadata:
   sections:
     - name: Skill Data Sources
       fields:
-        - name: weather_skill
-          type: text
-          label: Weather
-          value: skill-weather.openvoiceos
         - name: datetime_skill
           type: text
           label: Date and Time


### PR DESCRIPTION
The weather_skill is not used anymore with [this commit](https://github.com/OpenVoiceOS/skill-ovos-homescreen/commit/fd718ecf6f5c5cfecd59707f87ae0afc93b8e012).  This removes the setting