### PR TITLE
let anyone listening know when homescreen has been displayed

### DIFF
--- a/ui/idle.qml
+++ b/ui/idle.qml
@@ -136,6 +136,9 @@ Mycroft.CardDelegate {
         if(visible && idleRoot.textModel){
             textTimer.running = true
         }
+        if(visible) {
+            Mycroft.MycroftController.sendRequest("ovos.homescreen.displayed", {})
+        }
     }
 
     function getWeatherImagery(weathercode) {


### PR DESCRIPTION
- skills can listen for "ovos.homescreen.displayed" and decide to take action to update widgets data, or anything else.