### PR TITLE
Add bus events to control main view pages

### DIFF
--- a/ui/idle.qml
+++ b/ui/idle.qml
@@ -72,6 +72,11 @@ Mycroft.CardDelegate {
         onIntentRecevied: {
             if (type == "phal.brightness.control.auto.night.mode.enabled") {
                 mainView.currentIndex = 0
+            } else if (type == "ovos.homescreen.main_view.current_index.set") {
+                mainView.currentIndex = data.current_index
+                Mycroft.MycroftController.sendRequest("ovos.homescreen.main_view.current_index.get.response", {"current_index": mainView.currentIndex})
+            } else if (type == "ovos.homescreen.main_view.current_index.get") {
+                Mycroft.MycroftController.sendRequest("ovos.homescreen.main_view.current_index.get.response", {"current_index": mainView.currentIndex})
             }
         }
     }
@@ -244,6 +249,7 @@ Mycroft.CardDelegate {
                 } else if (mainView.currentIndex == 1) {
                     mainView.currentIndex = 2
                 }
+                Mycroft.MycroftController.sendRequest("ovos.homescreen.main_view.current_index.get.response", {"current_index": mainView.currentIndex})
             }
         }
     }
@@ -310,6 +316,7 @@ Mycroft.CardDelegate {
                 } else if (mainView.currentIndex == 2) {
                     mainView.currentIndex = 1
                 }
+                Mycroft.MycroftController.sendRequest("ovos.homescreen.main_view.current_index.get.response", {"current_index": mainView.currentIndex})
             }
         }
     }


### PR DESCRIPTION
Main view pages have the following views:
* Night mode: which shows just the time on a black background
* Main: usual view with wallpaper, time, date, etc.
* Boxes: for card configuration

This commit adds "ovos.gui.main_view.current_index.*" events to control which of these pages is active:

* get: trigger a get.response event
* get.response: broadcast current index in the data, i.e. `{"current_index": 1}`
* set: set active page. It uses the same data payload than get.response