### PR TITLE
Make time between weather and skill example updates configurable in settings

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -143,8 +143,10 @@ class OVOSHomescreenSkill(OVOSSkill):
         SkillApi.connect_bus(self.bus)
         self._load_skill_apis()
 
-        self.schedule_repeating_event(self.update_weather, callback_time, 900)
-        self.schedule_repeating_event(self.update_examples, callback_time, 900)
+        self.schedule_repeating_event(self.update_weather, callback_time,
+                                      self.weather_update_seconds)
+        self.schedule_repeating_event(self.update_examples, callback_time,
+                                      self.examples_update_seconds)
 
         self.bus.on("ovos.wallpaper.manager.loaded",
                     self.register_homescreen_wallpaper_provider)
@@ -180,7 +182,23 @@ class OVOSHomescreenSkill(OVOSSkill):
     @property
     def datetime_skill_id(self):
         return self.settings.get("datetime_skill")
-        
+
+    @property
+    def weather_update_seconds(self):
+        """
+        Duration in seconds between weather updates.
+        """
+        return self.settings.get("weather_update_seconds") or 900
+
+    @property
+    def examples_update_seconds(self):
+        """
+        Duration in seconds between updating skill examples. This is when
+        the list of examples is updated, NOT when the displayed example is
+        changed on screen.
+        """
+        return self.settings.get("examples_update_seconds") or 900
+
     #####################################################################
     # Homescreen Registration & Handling
     @resting_screen_handler("OVOSHomescreen")


### PR DESCRIPTION
Moves hard-coded durations to properties that read from skill settings
Some context [on Matrix](https://matrix.to/#/!ZhEZYNzKBfpEAhtQIz:matrix.org/$A0X7lVQXfAcNQLc46WGckJo2XAiZxsngHkoW1eHA8jc?via=matrix.org&via=nitro.chat&via=rx.haunted.computer)