### PR TITLE
chore(ovos-skill-homescreen): allow ovos-workshop<9.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ovos-utils>=0.0.38,<2.0.0
-ovos-workshop>=8.0.0,<8.1.0
+ovos-workshop>=8.0.0,<9.0.0
 ovos-date-parser>=0.0.3,<1.0.0
 ovos-bus-client>=1.0.0,<2.0.0


### PR DESCRIPTION
Update ovos-workshop dependency upper bound to <9.0.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraints to support a broader range of compatible versions, enabling access to additional minor updates while maintaining stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->