### PR TITLE
fix: declare requires-python >=3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 license = {text = "Apache-2.0"}
 authors = [{name = "Aix", email = "aix.m@outlook.com"}]
 keywords = ["ovos", "skill", "plugin"]
+requires-python = ">=3.10"
 dependencies = [
     "ovos-utils>=0.0.38,<1.0.0",
     "ovos-workshop>=8.0.0,<9.0.0",


### PR DESCRIPTION
Declares `requires-python = ">=3.10"` — homescreen depends on `ovos-workshop>=8.0.0` (Python 3.10+) but never declared a floor, so pip could install it on unsupported interpreters. Matches the rest of the OVOS stack.

**Why now:** this also cuts a needed release. homescreen's `dev` already carries `ovos-bus-client>=1.0.0,<3.0.0`, but the published **stable `3.0.3` caps `<2.0.0`** and `dev`'s `version.py` is `3.0.3a2` — *below* `3.0.3` — so the fix has been shadowed and never reachable. A `fix:` merge bumps the build → **`3.0.4a1`** (above `3.0.3`), finally publishing the `<3.0.0` cap. This is the **sole remaining blocker** preventing `ovos-releases`' alpha constraints from resolving `ovos-bus-client` 2.x.

(Note: a `chore:`/alpha-only bump would only produce `3.0.3a3`, still below `3.0.3` — it must be `fix:`/`feat:`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum required Python version to 3.10 or later. Users running earlier Python versions will need to upgrade to use this release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->