### PR TITLE
test: add ovoscope end-to-end tests

### DIFF
--- a/.github/workflows/ovoscope.yml
+++ b/.github/workflows/ovoscope.yml
@@ -1,0 +1,15 @@
+name: Ovoscope End-to-End Tests
+on:
+  push:
+    branches: [master, dev]
+  pull_request:
+    branches: [dev, master]
+  workflow_dispatch:
+
+jobs:
+  ovoscope:
+    uses: OpenVoiceOS/gh-automations/.github/workflows/ovoscope.yml@dev
+    secrets: inherit
+    with:
+      install_extras: 'test'
+      test_path: 'test/end2end/'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ test = [
     "pytest",
     "pytest-cov",
     "ovos-plugin-manager>=2.1.0,<3.0.0",
+    "ovoscope",
 ]
 
 [project.urls]

--- a/test/end2end/test_homescreen_e2e.py
+++ b/test/end2end/test_homescreen_e2e.py
@@ -1,0 +1,79 @@
+"""End-to-end (ovoscope) tests for ovos-skill-homescreen.
+
+The homescreen skill has no spoken intents — it is a resting-screen provider
+driven by bus events. These tests exercise that bus contract in a real
+MiniCroft (in-process SkillManager on a FakeBus):
+
+- it registers itself with the homescreen manager on load / reload
+- activating its display triggers the resting-screen handler, which announces
+  ``ovos.homescreen.displayed``
+
+GUI messages are ignored (ovoscope does not assert GUI rendering).
+"""
+from unittest import TestCase
+
+from ovos_bus_client.message import Message
+from ovos_bus_client.session import Session
+from ovos_utils.log import LOG
+from ovoscope import End2EndTest, CaptureSession, get_minicroft
+
+SKILL_ID = "ovos-skill-homescreen.openvoiceos"
+
+
+class TestHomescreenE2E(TestCase):
+    def setUp(self):
+        LOG.set_level("CRITICAL")
+        self.minicroft = get_minicroft([SKILL_ID])
+
+    def tearDown(self):
+        if self.minicroft:
+            self.minicroft.stop()
+
+    def test_skill_loads(self):
+        # the skill is loaded into the running MiniCroft
+        self.assertIn(SKILL_ID, self.minicroft.skill_ids)
+
+    def _session_msg(self, msg_type, data=None):
+        session = Session("test-session")
+        session.lang = "en-US"
+        return Message(msg_type, data or {},
+                       context={"session": session.serialize(),
+                                "source": "A", "destination": "B"})
+
+    def test_registers_with_homescreen_manager(self):
+        # on a manager reload the skill re-announces itself
+        source = self._session_msg("homescreen.manager.reload.list")
+        test = End2EndTest(
+            minicroft=self.minicroft,
+            skill_ids=[SKILL_ID],
+            source_message=source,
+            expected_messages=[
+                source,
+                Message("homescreen.manager.add",
+                        {"name": "OVOSHomescreen", "id": SKILL_ID}),
+            ],
+            test_message_number=False,
+            test_msg_data=False,
+            test_msg_context=False,
+            test_boot_sequence=False,
+            test_final_session=False,
+            test_routing=False,
+            test_active_skills=False,
+        )
+        test.execute(timeout=10)
+
+    def test_resting_screen_activates(self):
+        # activating the display runs the resting-screen handler, which
+        # announces the homescreen as displayed. The handler emits a variable
+        # set of messages (weather/notification requests depending on config),
+        # so assert membership rather than an exact ordered sequence.
+        src = self._session_msg("homescreen.manager.activate.display",
+                                {"homescreen_id": SKILL_ID})
+        session = CaptureSession(self.minicroft,
+                                 eof_msgs=["ovos.homescreen.displayed"])
+        session.capture(src, timeout=15)
+        messages = session.finish()
+        self.assertTrue(
+            any(m.msg_type == "ovos.homescreen.displayed" for m in messages),
+            "resting-screen handler did not emit 'ovos.homescreen.displayed'",
+        )


### PR DESCRIPTION
## ovoscope end-to-end tests for the resting-screen bus contract

The homescreen skill has no spoken intents — it is a resting-screen provider
driven by bus events. This adds an `ovoscope` end-to-end suite that runs the
skill in a real in-process MiniCroft and exercises that contract:

- **`test_skill_loads`** — the skill loads into MiniCroft.
- **`test_registers_with_homescreen_manager`** — on `homescreen.manager.reload.list`
  the skill re-announces itself via `homescreen.manager.add`.
- **`test_resting_screen_activates`** — `homescreen.manager.activate.display`
  triggers the resting-screen handler, which emits `ovos.homescreen.displayed`
  (asserted by membership via `CaptureSession`, since the handler emits a
  config-dependent set of messages).

Also adds `ovoscope` to the `test` extra and wires the reusable
`gh-automations/.github/workflows/ovoscope.yml@dev` workflow.

Local run: 3 passed. These run against the current GUI stack and act as a
regression guard for the upcoming GUIInterface migration.
